### PR TITLE
Properly detect Java under OpenJDK and Ubuntu 15.04

### DIFF
--- a/cli/utils.go
+++ b/cli/utils.go
@@ -228,14 +228,14 @@ var javaVersionService = func() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	//error!
 	return string(output), nil
 }
 
 //parses the vesion from
 func parseVersion(javaOut string) (ver float64, err error) {
 	strVer := ""
-	reg := re.MustCompile(`java version "(\d\.\d)?.*"`)
+	// under Ubuntu 15.4 openjdk `java -version` prints "openjdk version "1.8.0_45-internal""
+	reg := re.MustCompile(`(?:java|openjdk) version "(\d\.\d)?.*"`)
 	res := reg.FindStringSubmatch(javaOut)
 	if len(res) > 0 {
 		strVer = res[len(res)-1]

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -193,7 +193,7 @@ func AssertJava(minJavaVersion float64) error {
 		return err
 	}
 	//parse the output
-	ver, err := parseVesion(output)
+	ver, err := parseVersion(output)
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ var javaVersionService = func() (string, error) {
 }
 
 //parses the vesion from
-func parseVesion(javaOut string) (ver float64, err error) {
+func parseVersion(javaOut string) (ver float64, err error) {
 	strVer := ""
 	reg := re.MustCompile(`java version "(\d\.\d)?.*"`)
 	res := reg.FindStringSubmatch(javaOut)

--- a/cli/utils_test.go
+++ b/cli/utils_test.go
@@ -218,14 +218,14 @@ OpenJDK 64-Bit Server VM (build 24.65-b04, mixed mode)`
 )
 
 func TestParseVersion(t *testing.T) {
-	v, err := parseVesion(fmt.Sprintf(OracleJdkVersion, "1.7_u12"))
+	v, err := parseVersion(fmt.Sprintf(OracleJdkVersion, "1.7_u12"))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
 	if v != 1.7 {
 		t.Errorf("version was expected to be 1.7")
 	}
-	v, err = parseVesion(fmt.Sprintf(OpenJdkVersion, "1.7_12"))
+	v, err = parseVersion(fmt.Sprintf(OpenJdkVersion, "1.7_12"))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -233,14 +233,14 @@ func TestParseVersion(t *testing.T) {
 		t.Errorf("version was expected to be 1.7")
 	}
 
-	v, err = parseVesion(fmt.Sprintf(OracleJdkVersion, "1.6.12"))
+	v, err = parseVersion(fmt.Sprintf(OracleJdkVersion, "1.6.12"))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
 	if v != 1.6 {
 		t.Errorf("version was expected to be 1.6")
 	}
-	v, err = parseVesion(fmt.Sprintf(OpenJdkVersion, "1.8"))
+	v, err = parseVersion(fmt.Sprintf(OpenJdkVersion, "1.8"))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
@@ -251,15 +251,15 @@ func TestParseVersion(t *testing.T) {
 }
 func TestParseVersionErrors(t *testing.T) {
 	//no java out
-	_, err := parseVesion("")
+	_, err := parseVersion("")
 	if err == nil {
 		t.Errorf("Expected error not returned for empty string")
 	}
-	_, err = parseVesion("this is not a version line")
+	_, err = parseVersion("this is not a version line")
 	if err == nil {
 		t.Errorf("Expected error not returned for nonsense")
 	}
-	_, err = parseVesion(fmt.Sprintf(OpenJdkVersion, "arg!"))
+	_, err = parseVersion(fmt.Sprintf(OpenJdkVersion, "arg!"))
 	if err == nil {
 		t.Errorf("Expected error not returned for an unparseable version")
 	}

--- a/cli/utils_test.go
+++ b/cli/utils_test.go
@@ -215,6 +215,9 @@ Java HotSpot(TM) Client VM (build 24.65-b04, mixed mode, sharing)`
 	OpenJdkVersion = `java version "%s"
 OpenJDK Runtime Environment (IcedTea 2.5.2) (7u65-2.5.2-3~14.04)
 OpenJDK 64-Bit Server VM (build 24.65-b04, mixed mode)`
+	OpenJdkVersionUbuntu = `openjdk version "%s"
+OpenJDK Runtime Environment (build 1.8.0_45-internal-b14)
+OpenJDK 64-Bit Server VM (build 25.45-b02, mixed mode)`
 )
 
 func TestParseVersion(t *testing.T) {
@@ -245,8 +248,16 @@ func TestParseVersion(t *testing.T) {
 		t.Errorf("Unexpected error %v", err)
 	}
 	if v != 1.8 {
-		t.Errorf("version was expected to be 1.6")
+		t.Errorf("version was expected to be 1.8")
 	}
+	v, err = parseVersion(fmt.Sprintf(OpenJdkVersionUbuntu, "1.8.0_45-internal"))
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if v != 1.8 {
+		t.Errorf("version was expected to be 1.8")
+	}
+
 
 }
 func TestParseVersionErrors(t *testing.T) {
@@ -288,6 +299,12 @@ func TestAssertJava(t *testing.T) {
 	}
 	if err := AssertJava(1.7); err == nil {
 		t.Errorf("Expected error not returned")
+	}
+	javaVersionService = func() (string, error) {
+		return fmt.Sprintf(OpenJdkVersionUbuntu, "1.8.0_45-internal"), nil
+	}
+	if err := AssertJava(1.8); err != nil {
+		t.Errorf("Unexpected error %v", err.Error())
 	}
 
 }


### PR DESCRIPTION
When running the cli under Ubuntu 15.04 with OpenJDK I get the following error:

``` console
eglic@wharton:~/src$ /opt/daisy-pipeline2-cli/dp2 
Java version error:
	Please make sure that java is accessible and the version is equal or greater than 1.7
	Error: Couldn't find version in openjdk version "1.8.0_45-internal"
OpenJDK Runtime Environment (build 1.8.0_45-internal-b14)
OpenJDK 64-Bit Server VM (build 25.45-b02, mixed mode)
```

This pr should fix this