### PR TITLE
Improved Java version checking

### DIFF
--- a/cli/utils.go
+++ b/cli/utils.go
@@ -186,7 +186,7 @@ func getLastIdPath(currentOs string) string {
 	return path
 }
 
-func AssertJava(minJavaVersion float64) error {
+func AssertJava(minJavaVersion int) error {
 	//get the output
 	output, err := javaVersionService()
 	if err != nil {
@@ -232,16 +232,18 @@ var javaVersionService = func() (string, error) {
 }
 
 //parses the vesion from
-func parseVersion(javaOut string) (ver float64, err error) {
+func parseVersion(javaOut string) (ver int, err error) {
 	strVer := ""
-	// under Ubuntu 15.4 openjdk `java -version` prints "openjdk version "1.8.0_45-internal""
-	reg := re.MustCompile(`(?:java|openjdk) version "(\d\.\d)?.*"`)
+	// The first line of `java -version` contains the version string inside quotes.
+	// Ignore "1." from the start of the version string. We regard version "1.6" as version 6, "1.7" as 7 etc.
+	reg := re.MustCompile(`.*"(1\.)?(\d+).*?".*`)
 	res := reg.FindStringSubmatch(javaOut)
 	if len(res) > 0 {
 		strVer = res[len(res)-1]
 	} else {
 		return ver, fmt.Errorf("Couldn't find version in %s", javaOut)
 	}
-	return strconv.ParseFloat(strVer, 64)
+	productVersion, err := strconv.ParseInt(strVer, 10, 64)
+	return int(productVersion), err
 
 }

--- a/cli/utils_test.go
+++ b/cli/utils_test.go
@@ -209,53 +209,60 @@ func TestHomePath(t *testing.T) {
 }
 
 const (
-	OracleJdkVersion = `java version "%s"
+	OracleJdkVersion = `java version %s
 Java(TM) SE Runtime Environment (build 1.7.0_67-b01)
 Java HotSpot(TM) Client VM (build 24.65-b04, mixed mode, sharing)`
-	OpenJdkVersion = `java version "%s"
+	OpenJdkVersion = `java version %s
 OpenJDK Runtime Environment (IcedTea 2.5.2) (7u65-2.5.2-3~14.04)
 OpenJDK 64-Bit Server VM (build 24.65-b04, mixed mode)`
-	OpenJdkVersionUbuntu = `openjdk version "%s"
+	OpenJdkVersionUbuntu = `openjdk version %s
 OpenJDK Runtime Environment (build 1.8.0_45-internal-b14)
 OpenJDK 64-Bit Server VM (build 25.45-b02, mixed mode)`
 )
 
 func TestParseVersion(t *testing.T) {
-	v, err := parseVersion(fmt.Sprintf(OracleJdkVersion, "1.7_u12"))
+	v, err := parseVersion(fmt.Sprintf(OracleJdkVersion, "\"1.7_u12\""))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	if v != 1.7 {
-		t.Errorf("version was expected to be 1.7")
+	if v != 7 {
+		t.Errorf("version was expected to be 7")
 	}
-	v, err = parseVersion(fmt.Sprintf(OpenJdkVersion, "1.7_12"))
+	v, err = parseVersion(fmt.Sprintf(OpenJdkVersion, "\"1.7_12\""))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	if v != 1.7 {
-		t.Errorf("version was expected to be 1.7")
+	if v != 7 {
+		t.Errorf("version was expected to be 7")
 	}
 
-	v, err = parseVersion(fmt.Sprintf(OracleJdkVersion, "1.6.12"))
+	v, err = parseVersion(fmt.Sprintf(OracleJdkVersion, "\"1.6.12\""))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	if v != 1.6 {
-		t.Errorf("version was expected to be 1.6")
+	if v != 6 {
+		t.Errorf("version was expected to be 6")
 	}
-	v, err = parseVersion(fmt.Sprintf(OpenJdkVersion, "1.8"))
+	v, err = parseVersion(fmt.Sprintf(OpenJdkVersion, "\"1.8\""))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	if v != 1.8 {
-		t.Errorf("version was expected to be 1.8")
+	if v != 8 {
+		t.Errorf("version was expected to be 8")
 	}
-	v, err = parseVersion(fmt.Sprintf(OpenJdkVersionUbuntu, "1.8.0_45-internal"))
+	v, err = parseVersion(fmt.Sprintf(OpenJdkVersionUbuntu, "\"1.8.0_45-internal\""))
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	if v != 1.8 {
-		t.Errorf("version was expected to be 1.8")
+	if v != 8 {
+		t.Errorf("version was expected to be 8")
+	}
+	v, err = parseVersion(fmt.Sprintf(OpenJdkVersionUbuntu, "\"10.0.2\" 2018-07-17"))
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if v != 10 {
+		t.Errorf("version was expected to be 10")
 	}
 
 
@@ -283,27 +290,33 @@ func TestAssertJava(t *testing.T) {
 		javaVersionService = back
 	}()
 	javaVersionService = func() (string, error) {
-		return fmt.Sprintf(OracleJdkVersion, "1.7_u89"), nil
+		return fmt.Sprintf(OracleJdkVersion, "\"1.7_u89\""), nil
 	}
-	if err := AssertJava(1.7); err != nil {
+	if err := AssertJava(7); err != nil {
 		t.Errorf("Unexpected error %v", err.Error())
 	}
 	javaVersionService = func() (string, error) {
-		return fmt.Sprintf(OracleJdkVersion, "1.6_u89"), nil
+		return fmt.Sprintf(OracleJdkVersion, "\"1.6_u89\""), nil
 	}
-	if err := AssertJava(1.7); err == nil {
+	if err := AssertJava(7); err == nil {
 		t.Errorf("Expected error not returned")
 	}
 	javaVersionService = func() (string, error) {
 		return "", fmt.Errorf("error!")
 	}
-	if err := AssertJava(1.7); err == nil {
+	if err := AssertJava(7); err == nil {
 		t.Errorf("Expected error not returned")
 	}
 	javaVersionService = func() (string, error) {
-		return fmt.Sprintf(OpenJdkVersionUbuntu, "1.8.0_45-internal"), nil
+		return fmt.Sprintf(OpenJdkVersionUbuntu, "\"1.8.0_45-internal\""), nil
 	}
-	if err := AssertJava(1.8); err != nil {
+	if err := AssertJava(8); err != nil {
+		t.Errorf("Unexpected error %v", err.Error())
+	}
+	javaVersionService = func() (string, error) {
+		return fmt.Sprintf(OpenJdkVersionUbuntu, "\"10.0.2\" 2018-07-17"), nil
+	}
+	if err := AssertJava(10); err != nil {
 		t.Errorf("Unexpected error %v", err.Error())
 	}
 

--- a/dp2/dp2.go
+++ b/dp2/dp2.go
@@ -8,7 +8,7 @@ import (
 	"github.com/daisy/pipeline-cli-go/cli"
 )
 
-var minJavaVersion = 1.7
+var minJavaVersion = 9
 
 func main() {
 	log.SetFlags(log.Lshortfile)


### PR DESCRIPTION
- Better parsing of version string. Now handles for instance: openjdk version "10.0.2" 2018-07-17
- Use product version instead of developer version
- Require Java version 9 instead of 7
