### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -209,21 +209,21 @@ func (c *Cli) addConfigOptions(conf Config) {
 	})
 }
 
-//Adds the command to the cli and stores the it into the scripts list
+//AddScriptCommand adds the command to the cli and stores the it into the scripts list
 func (c *Cli) AddScriptCommand(name, desc string, fn func(string, ...string) error, request *JobRequest) *subcommand.Command {
 	cmd := c.Parser.AddCommand(name, desc, fn)
 	c.Scripts = append(c.Scripts, &ScriptCommand{cmd, request})
 	return cmd
 }
 
-//Adds a static command to the cli and keeps track of it for the displaying the help
+//AddCommand adds a static command to the cli and keeps track of it for the displaying the help
 func (c *Cli) AddCommand(name, desc string, fn func(string, ...string) error) *subcommand.Command {
 	cmd := c.Parser.AddCommand(name, desc, fn)
 	c.StaticCommands = append(c.StaticCommands, cmd)
 	return cmd
 }
 
-//Adds admin related commands to the cli and keeps track of it for displaying help
+//AddAdminCommand adds admin related commands to the cli and keeps track of it for displaying help
 func (c *Cli) AddAdminCommand(name, desc string, fn func(string, ...string) error) *subcommand.Command {
 	cmd := c.Parser.AddCommand(name, desc, fn)
 	c.AdminCommands = append(c.AdminCommands, cmd)

--- a/cli/config.go
+++ b/cli/config.go
@@ -128,7 +128,7 @@ func (c Config) UpdateDebug() {
 	}
 }
 
-//Returns the Url composed by HOSTNAME:PORT/PATH/
+//Url returns the Url composed by HOSTNAME:PORT/PATH/
 func (c Config) Url() string {
 	return fmt.Sprintf("%v:%v/%v/", c[HOST], c[PORT], c[PATH])
 }

--- a/cli/link.go
+++ b/cli/link.go
@@ -105,7 +105,7 @@ func bringUp(pLink *PipelineLink) error {
 	return nil
 }
 
-//ScriptList returns the list of scripts available in the framework
+//Scripts returns the list of scripts available in the framework
 func (p PipelineLink) Scripts() (scripts []pipeline.Script, err error) {
 	scriptsStruct, err := p.pipeline.Scripts()
 	if err != nil {
@@ -122,7 +122,7 @@ func (p PipelineLink) Scripts() (scripts []pipeline.Script, err error) {
 	return scripts, err
 }
 
-//Gets the job identified by the jobId
+//Job gets the job identified by the jobId
 func (p PipelineLink) Job(jobId string) (job pipeline.Job, err error) {
 	job, err = p.pipeline.Job(jobId, 0)
 	return
@@ -134,7 +134,7 @@ func (p PipelineLink) Delete(jobId string) (ok bool, err error) {
 	return
 }
 
-//Return the zipped results as a []byte
+//Results returns the zipped results as a []byte
 func (p PipelineLink) Results(jobId string, w io.Writer) (ok bool, err error) {
 	return p.pipeline.Results(jobId, w)
 }
@@ -200,7 +200,7 @@ type Message struct {
 	Error    error
 }
 
-//Returns a simple string representation of the messages strucutre:
+//String returns a simple string representation of the messages strucutre:
 //[LEVEL]   Message content
 func (m Message) String() string {
 	if m.Message != "" {
@@ -226,7 +226,7 @@ func (m Message) String() string {
 	}
 }
 
-//Executes the job request and returns a channel fed with the job's messages,errors, and status.
+//Execute executes the job request and returns a channel fed with the job's messages,errors, and status.
 //The last message will have no contents but the status of the in which the job finished
 func (p PipelineLink) Execute(jobReq JobRequest) (job pipeline.Job, messages chan Message, err error) {
 	req, err := jobRequestToPipeline(jobReq, p)

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -106,7 +106,7 @@ func NewZipInflator(folder string) *ZipInflator {
 
 }
 
-//Writes the  data to a intermediate buffer
+//Write writes the  data to a intermediate buffer
 func (z *ZipInflator) Write(data []byte) (int, error) {
 	return z.buff.Write(data)
 }

--- a/libs/blackterm/render.go
+++ b/libs/blackterm/render.go
@@ -11,6 +11,7 @@ import (
 
 /*
 Process a subset of markdown elements and prints them with flying colours!
+*/Process a subset of markdown elements and prints them with flying colours!
 */
 func Markdown(input []byte) []byte {
 	tr := NewTerminalRenderer()

--- a/libs/go-subcommand/flag.go
+++ b/libs/go-subcommand/flag.go
@@ -42,7 +42,7 @@ func (f *Flag) Must(isIt bool) {
 	f.Mandatory = isIt
 }
 
-//Gets a help friendly flag representation:
+//String gets a help friendly flag representation:
 //-o,--option  OPTION           This option does this and that
 //-s,--switch                   This is a switch
 //-i,--ignoreme [IGNOREME]      Optional option

--- a/libs/go-subcommand/parser.go
+++ b/libs/go-subcommand/parser.go
@@ -27,7 +27,7 @@ func (p *Parser) OnCommand(fn CommandFunction) {
 	p.fn = fn
 }
 
-//Execute this function once the flags have been consumed. This can be used to dinamically
+//PostFlags executes this function once the flags have been consumed. This can be used to dinamically
 //add commands depending on the flags' state
 func (p *Parser) PostFlags(fn func() error) {
 	p.postFlagsFn = fn

--- a/libs/go-subcommand/subcommand.go
+++ b/libs/go-subcommand/subcommand.go
@@ -28,7 +28,7 @@ type Flagged interface {
 	Flags() []Flag
 }
 
-//getFlags returns a slice containing the c's flags
+//Flags returns a slice containing the c's flags
 func (c *Command) Flags() []Flag {
 	//return c.Name
 	flags := make([]Flag, 0)
@@ -58,7 +58,7 @@ func (c *Command) NonMandatoryFlags() []Flag {
 	return flags
 }
 
-//Returns the command parent
+//Parent returns the command parent
 func (c Command) Parent() *Command {
 	return c.parent
 }
@@ -76,7 +76,7 @@ func newCommand(parent *Command, name string, description string, fn CommandFunc
 	}
 }
 
-//Adds a new option to the command to be used as "--option OPTION" (expects a value after the flag) in the command line
+//AddOption adds a new option to the command to be used as "--option OPTION" (expects a value after the flag) in the command line
 //The short definition has no length restriction but it should be significantly shorter that its long counterpart, it can be an empty string.
 //The function fn receives the name of the option and its value
 //Example:
@@ -91,7 +91,7 @@ func (c *Command) AddOption(long, short, shortDesc, longDesc, values string, fn 
 	return flag
 }
 
-//Adds a new switch to the command to be used as "--switch" (expects no value after the flag) in the command line
+//AddSwitch adds a new switch to the command to be used as "--switch" (expects no value after the flag) in the command line
 //The short definition has no length restriction but it should be significantly shorter that its long counterpart, it can be an empty string.
 //The function fn receives two strings, the first is the switch name and the second is just an empty string
 //Example:


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?