### PR TITLE
feat: use DAISY Pipeline app if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Global Options:
        --port [PORT]    Pipeline's webserivce port (default 8181)
        --app_path [APPPATH]  DAISY Pipeline app or Pipeline webservice executable path (default to empty)
        --debug [DEBUG]  Print debug messages. true or false.  (default false)
-       --path [path]      Pipeline's webservice path, as in http://daisy.org:8181/path (default ws)
+       --ws_path [WS_PATH]      Pipeline's webservice path, as in http://daisy.org:8181/path (default ws)
        --client_secret [CLIENT_SECRET]  Client secrect for authenticated requests (default supersecret)
        --timeout [TIMEOUT]      Http connection timeout in seconds (default 10)
        --starting [STARTING]    Start the DAISY Pipeline app or the webservice in the local computer if it is not running. true or false (default false)

--- a/README.md
+++ b/README.md
@@ -63,14 +63,12 @@ Modify the settings in the file config.yml or alternatively use the global witch
 Global Options:
        --host [HOST]    Pipeline's webservice host (default http://localhost)
        --port [PORT]    Pipeline's webserivce port (default 8181)
-       --exec_line_win [EXEC_LINE_WIN]  Pipeline webserivice executable path in windows systems (default )
+       --app_path [APPPATH]  DAISY Pipeline app or Pipeline webservice executable path (default to empty)
        --debug [DEBUG]  Print debug messages. true or false.  (default false)
-       --ws_path [WS_PATH]      Pipeline's webservice path, as in http://daisy.org:8181/path (default ws)
-       --exec_line_nix [EXEC_LINE_NIX]  Pipeline webserivice executable path in unix-like systems (default /home/javi/bin/pipeline2)
+       --path [path]      Pipeline's webservice path, as in http://daisy.org:8181/path (default ws)
        --client_secret [CLIENT_SECRET]  Client secrect for authenticated requests (default supersecret)
        --timeout [TIMEOUT]      Http connection timeout in seconds (default 10)
-       --starting [STARTING]    Start the webservice in the local computer if it is not running. true or false (default false)
-       --ws_timeup [WS_TIMEUP]  Time to wait until the webserivce starts in seconds (default 25)
+       --starting [STARTING]    Start the DAISY Pipeline app or the webservice in the local computer if it is not running. true or false (default false)
        --client_key [CLIENT_KEY]        Client key for authenticated requests (default clientid)
        -f,--file [FILE]        Alternative configuration file
 ```

--- a/README.md
+++ b/README.md
@@ -57,18 +57,5 @@ Detailed help for a single command:     dp2 help COMMAND
 Configuration
 -------------
 
-Modify the settings in the file config.yml or alternatively use the global witches:
-
-```
-Global Options:
-       --host [HOST]    Pipeline's webservice host (default http://localhost)
-       --port [PORT]    Pipeline's webserivce port (default 8181)
-       --app_path [APPPATH]  DAISY Pipeline app or Pipeline webservice executable path (default to empty)
-       --debug [DEBUG]  Print debug messages. true or false.  (default false)
-       --ws_path [WS_PATH]      Pipeline's webservice path, as in http://daisy.org:8181/path (default ws)
-       --client_secret [CLIENT_SECRET]  Client secrect for authenticated requests (default supersecret)
-       --timeout [TIMEOUT]      Http connection timeout in seconds (default 10)
-       --starting [STARTING]    Start the DAISY Pipeline app or the webservice in the local computer if it is not running. true or false (default false)
-       --client_key [CLIENT_KEY]        Client key for authenticated requests (default clientid)
-       -f,--file [FILE]        Alternative configuration file
-```
+Modify the settings in config.yml or alternatively use the global
+switches (run `dp2 help -g` to get the list).

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -205,6 +205,7 @@ func (c *Cli) addConfigOptions(conf Config) {
 			log.Printf(err.Error())
 			return fmt.Errorf("File not found %v", filePath)
 		}
+		conf[CONFPATH] = filePath
 		return conf.FromYaml(file)
 	})
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -168,7 +168,10 @@ func (c *Cli) setHelp() {
 //Adds the configuration global options to the parser
 func (c *Cli) addConfigOptions(conf Config) {
 	for option, desc := range config_descriptions {
-		c.AddOption(option, "", fmt.Sprintf("%v (default %v)", desc, conf[option]), "", "", func(optName string, value string) error {
+		if conf[option] != "" {
+			desc = fmt.Sprintf("%v (default %v)", desc, conf[option])
+		}
+		c.AddOption(option, "", desc, "", "", func(optName string, value string) error {
 			log.Println("option:", optName, "value:", value)
 			switch conf[optName].(type) {
 			case int:

--- a/cli/cli.go.in
+++ b/cli/cli.go.in
@@ -205,6 +205,7 @@ func (c *Cli) addConfigOptions(conf Config) {
 			log.Printf(err.Error())
 			return fmt.Errorf("File not found %v", filePath)
 		}
+		conf[CONFPATH] = filePath
 		return conf.FromYaml(file)
 	})
 }

--- a/cli/cli.go.in
+++ b/cli/cli.go.in
@@ -168,7 +168,10 @@ func (c *Cli) setHelp() {
 //Adds the configuration global options to the parser
 func (c *Cli) addConfigOptions(conf Config) {
 	for option, desc := range config_descriptions {
-		c.AddOption(option, "", fmt.Sprintf("%v (default %v)", desc, conf[option]), "", "", func(optName string, value string) error {
+		if conf[option] != "" {
+			desc = fmt.Sprintf("%v (default %v)", desc, conf[option])
+		}
+		c.AddOption(option, "", desc, "", "", func(optName string, value string) error {
 			log.Println("option:", optName, "value:", value)
 			switch conf[optName].(type) {
 			case int:

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -262,6 +262,7 @@ func TestConfigOptions(t *testing.T) {
 		PORT:         80,
 		PATH:         "pipeline",
 		APPPATH:      "the_noose",
+		EXECLINE:     "",
 		CLIENTKEY:    "rounded",
 		CLIENTSECRET: "he_likes_justin_beiber",
 		TIMEOUT:      3,

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -219,10 +219,7 @@ func TestConfigIntOptions(t *testing.T) {
 	if err == nil {
 		t.Errorf("Port: non numeric type controll failed")
 	}
-	err = cli.Run([]string{"--" + WSTIMEUP, "abit", "test"})
-	if err == nil {
-		t.Errorf("ws_time_out: non numeric type controll failed")
-	}
+
 	err = cli.Run([]string{"--timeout" + TIMEOUT, "now!", "test"})
 	if err == nil {
 		t.Errorf("Port: non numeric type controll failed")
@@ -264,8 +261,7 @@ func TestConfigOptions(t *testing.T) {
 		HOST:         "http://google.com",
 		PORT:         80,
 		PATH:         "pipeline",
-		WSTIMEUP:     1,
-		EXECLINE:     "the_noose",
+		APPPATH:      "the_noose",
 		CLIENTKEY:    "rounded",
 		CLIENTSECRET: "he_likes_justin_beiber",
 		TIMEOUT:      3,
@@ -276,8 +272,7 @@ func TestConfigOptions(t *testing.T) {
 	err = cli.Run([]string{"--" + HOST, exp[HOST].(string),
 		"--" + PORT, strconv.Itoa(exp[PORT].(int)),
 		"--" + PATH, exp[PATH].(string),
-		"--" + WSTIMEUP, strconv.Itoa(exp[WSTIMEUP].(int)),
-		"--" + EXECLINE, exp[EXECLINE].(string),
+		"--" + APPPATH, exp[APPPATH].(string),
 		"--" + CLIENTKEY, exp[CLIENTKEY].(string),
 		"--" + CLIENTSECRET, exp[CLIENTSECRET].(string),
 		"--" + TIMEOUT, strconv.Itoa(exp[TIMEOUT].(int)),

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -268,6 +268,7 @@ func TestConfigOptions(t *testing.T) {
 		TIMEOUT:      3,
 		DEBUG:        true,
 		STARTING:     true,
+		CONFPATH:     DEFAULT_FILE,
 	}
 
 	err = cli.Run([]string{"--" + HOST, exp[HOST].(string),
@@ -337,6 +338,8 @@ func TestConfigFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}
-	tCompareCnfs(res, EXP, t)
+	EXP2 := copyMap(EXP)
+	EXP2[CONFPATH] = tmpFile.Name()
+	tCompareCnfs(res, EXP2, t)
 
 }

--- a/cli/config.go
+++ b/cli/config.go
@@ -21,7 +21,7 @@ import (
 const (
 	HOST         = "host"
 	PORT         = "port"
-	PATH         = "path"
+	PATH         = "ws_path"
 	APPPATH      = "app_path"
 	CLIENTKEY    = "client_key"
 	CLIENTSECRET = "client_secret"

--- a/cli/config.go
+++ b/cli/config.go
@@ -56,15 +56,15 @@ var config = Config{
 //Config items descriptions
 var config_descriptions = map[string]string{
 
-	HOST:         "Pipeline's webservice host",
-	PORT:         "Pipeline's webserivce port",
-	PATH:         "Pipeline's webservice path, as in http://daisy.org:8181/path",
-	APPPATH:      "Path of the DAISY Pipeline app or the pipeline launch script to use the webservice. If empty or only containing 'DAISY Pipeline', the app is searched in the PATH",
+	HOST:         "Host part of webservice address. Leave empty if you wish to use the app_path setting",
+	PORT:         "Port part of webservice address. Leave empty if you wish to use the app_path setting",
+	PATH:         "Path part of webservice address, as in HOST:PORT/PATH (e.g. http://localhost:8181/ws). Leave empty if you wish to use the app_path setting",
+	APPPATH:      "Path to the DAISY Pipeline app. If left empty, the PATH is searched for a \"DAISY Pipeline\" executable",
 	CLIENTKEY:    "Client key for authenticated requests",
-	CLIENTSECRET: "Client secrect for authenticated requests",
-	TIMEOUT:      "Http connection timeout in seconds",
-	DEBUG:        "Print debug messages. true or false. ",
-	STARTING:     "Start the webservice or the DAISY Pipeline app in the local computer if it is not running. true or false",
+	CLIENTSECRET: "Client secret for authenticated requests",
+	TIMEOUT:      "Timeout for requests to the webservice in seconds",
+	DEBUG:        "Print debug messages",
+	STARTING:     "Start the DAISY Pipeline app if it is not running",
 }
 
 //Makes a copy of the default config
@@ -224,7 +224,10 @@ func (c Config) ExecPath() string {
 
 func (c Config) buildPath(base string) string {
 	execpath := c[APPPATH].(string)
-	//empty app path defaults to looking for DAISY Pipeline app in the PATH
+	// An empty app path defaults to looking for DAISY Pipeline app in
+	// the PATH. Note that we choose not to use "DAISY Pipeline" as
+	// the default config value, because this would result in a
+	// "provided app path was not found" warning if no app is found.
 	if execpath == "" {
 		execpath = "DAISY Pipeline"
 	}

--- a/cli/config.go
+++ b/cli/config.go
@@ -187,16 +187,31 @@ func (c Config) UpdateDebug() {
 	}
 }
 
-// Returns the Url composed by `HOSTNAME:PORT/PATH/`
+// Returns the Url composed by `HOST:PORT/PATH/`
+//
+// For each HOST, PORT and PATH values, if not defined in the config file,
+// the default values are used to build the url (http://localhost:8181/ws/).
 //
 // Note that the PATH is trimmed from slashes at begining or end of the string
 func (c Config) Url() string {
-	path := strings.Trim(c[PATH].(string), "/")
+	var path = config[PATH].(string);
+	if c[PATH] != nil {
+		path = strings.Trim(c[PATH].(string), "/")
+	}
 	if (path != "") {
 		// re-add trailing slash at the end of the path
 		path += "/"
 	}
-	return fmt.Sprintf("%v:%v/%v", c[HOST], c[PORT], path)
+	var host = config[HOST].(string)
+	if (c[HOST] != nil) {
+		host = c[HOST].(string)
+	}
+	var port = config[PORT].(int)
+	if (c[PORT] != nil) {
+		port = c[PORT].(int)
+	}
+	testUrl := fmt.Sprintf("%v:%v/%v", host, port, path)
+	return testUrl
 }
 func (c Config) ExecPath() string {
 	// this will possibly not resolve symlinked executables

--- a/cli/config.go
+++ b/cli/config.go
@@ -191,7 +191,12 @@ func (c Config) UpdateDebug() {
 //
 // Note that the PATH is trimmed from slashes at begining or end of the string
 func (c Config) Url() string {
-	return fmt.Sprintf("%v:%v/%v/", c[HOST], c[PORT], strings.Trim(c[PATH].(string), "/"))
+	path := strings.Trim(c[PATH].(string), "/")
+	if (path != "") {
+		// re-add trailing slash at the end of the path
+		path += "/"
+	}
+	return fmt.Sprintf("%v:%v/%v", c[HOST], c[PORT], path)
 }
 func (c Config) ExecPath() string {
 	// this will possibly not resolve symlinked executables

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -30,6 +30,7 @@ starting: true
 		"port":          9999,
 		"ws_path":       "ws",
 		"app_path":      "", // value should be emptied by the loading to avoid loading non existing programs
+		"exec_line":     "",
 		"client_key":    "clientid",
 		"client_secret": "supersecret",
 		"timeout":       10,
@@ -143,14 +144,14 @@ func TestBuildPath(t *testing.T) {
 	conf := Config{}
 	conf[APPPATH] = "/home/cosa/pipeline2"
 	base := "/tmp"
-	path := conf.buildPath(base)
+	path := buildPath(base, conf[APPPATH].(string))
 	fmt.Printf("path %+v\n", path)
 	if path != conf[APPPATH] {
 		t.Errorf("If the path is absolute no resolving against base should be done %v %v", path, conf[APPPATH])
 
 	}
 	conf[APPPATH] = "../cosa/pipeline2"
-	path = conf.buildPath(base)
+	path = buildPath(base, conf[APPPATH].(string))
 	if path != filepath.FromSlash("/tmp/../cosa/pipeline2") {
 		t.Errorf("The path is not being resolved %v", path)
 

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -14,7 +14,7 @@ var (
 	YAML = `
 host: http://daisy.org
 port: 9999
-path: ws
+ws_path: ws
 app_path: prog
 client_key: clientid
 client_secret: supersecret
@@ -28,7 +28,7 @@ starting: true
 		"url":           "http://localhost:8181/ws/",
 		"host":          "http://daisy.org",
 		"port":          9999,
-		"path":          "ws",
+		"ws_path":       "ws",
 		"app_path":      "", // value should be emptied by the loading to avoid loading non existing programs
 		"client_key":    "clientid",
 		"client_secret": "supersecret",

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -12,18 +12,12 @@ import (
 
 var (
 	YAML = `
-#WS CONFIGURATION
 host: http://daisy.org
 port: 9999
-ws_path: ws
-ws_timeup: 10
-#DP2 launch config 
-exec_line: prog 
-local: true
-# ROBOT CONF
+path: ws
+app_path: prog
 client_key: clientid
 client_secret: supersecret
-#connection settings
 timeout: 10
 #debug
 debug: true 
@@ -34,13 +28,12 @@ starting: true
 		"url":           "http://localhost:8181/ws/",
 		"host":          "http://daisy.org",
 		"port":          9999,
-		"ws_path":       "ws",
-		"ws_timeup":     10,
-		"exec_line":     "prog",
+		"path":          "ws",
+		"app_path":      "", // value should be emptied by the loading to avoid loading non existing programs
 		"client_key":    "clientid",
 		"client_secret": "supersecret",
 		"timeout":       10,
-		"starting":      true,
+		"starting":      false, // should be reset to false as the prog exec does not exists
 		"debug":         true,
 	}
 )
@@ -65,14 +58,9 @@ func tCompareCnfs(one, exp Config, t *testing.T) {
 	if res != exp[test] {
 		t.Errorf(T_STRING, test, exp[test], res)
 	}
-	test = WSTIMEUP
-	res = one[WSTIMEUP]
-	if res != exp[test] {
-		t.Errorf(T_STRING, test, exp[test], res)
-	}
 
-	test = EXECLINE
-	res = one[EXECLINE]
+	test = APPPATH
+	res = one[APPPATH]
 	if res != exp[test] {
 		t.Errorf(T_STRING, test, exp[test], res)
 	}
@@ -153,15 +141,15 @@ func TestNewConfigDefaultFile(t *testing.T) {
 func TestBuildPath(t *testing.T) {
 	//from a absolute path
 	conf := Config{}
-	conf[EXECLINE] = "/home/cosa/pipeline2"
+	conf[APPPATH] = "/home/cosa/pipeline2"
 	base := "/tmp"
 	path := conf.buildPath(base)
 	fmt.Printf("path %+v\n", path)
-	if path != conf[EXECLINE] {
-		t.Errorf("If the path is absolute no resolving against base should be done %v %v", path, conf[EXECLINE])
+	if path != conf[APPPATH] {
+		t.Errorf("If the path is absolute no resolving against base should be done %v %v", path, conf[APPPATH])
 
 	}
-	conf[EXECLINE] = "../cosa/pipeline2"
+	conf[APPPATH] = "../cosa/pipeline2"
 	path = conf.buildPath(base)
 	if path != filepath.FromSlash("/tmp/../cosa/pipeline2") {
 		t.Errorf("The path is not being resolved %v", path)

--- a/cli/link.go
+++ b/cli/link.go
@@ -92,7 +92,9 @@ func (p PipelineLink) IsLocal() bool {
 func bringUp(pLink *PipelineLink) error {
 	var alive pipeline.Alive
 	var err error
-	if !(pLink.config[HOST].(string) == "" && pLink.config[PORT].(int) == 0 && pLink.config[PATH].(string) == "") {
+	if !((pLink.config[HOST] == nil || pLink.config[HOST].(string) == "") &&
+		 (pLink.config[HOST] == nil || pLink.config[PORT].(int) == 0) &&
+		 (pLink.config[PATH] == nil || pLink.config[PATH].(string) == "")) {
 		// A webservice is configured to be used in loaded configuration either from
 		// - the user provided config (config file or command line)
 		// - The default webservice config, reinstated due to missing or incorrect app path
@@ -132,7 +134,7 @@ func bringUp(pLink *PipelineLink) error {
 		}
 		// if no running app process was found, continue here
 		// If the starting flag was set to true (set in config + valid path was provided)
-		if pLink.config[STARTING].(bool) {
+		if pLink.config[STARTING] != nil && pLink.config[STARTING].(bool) {
 			// execpath is validated now at the config level in config.FromYaml
 			// and the ExecPath returns the resolved path
 			execpath := pLink.config.ExecPath()

--- a/cli/link_test.go
+++ b/cli/link_test.go
@@ -252,7 +252,7 @@ func TestBadStart(t *testing.T) {
 	pipeline := newPipelineTest(true)
 	pipeline.authentication = true
 	config[STARTING] = true
-	config[EXECLINE] = "nonexistingprogram"
+	config[APPPATH] = "nonexistingprogram"
 	link := PipelineLink{pipeline: pipeline, config: config}
 	err := link.Init()
 	if err == nil {

--- a/dp2/config.yml
+++ b/dp2/config.yml
@@ -3,7 +3,7 @@ host: http://localhost
 # Pipeline's webservice port
 port: 8181
 # Pipeline's webservice path, as in HOST:PORT/PATH (e.g. http://localhost:8181/ws)
-path: ws
+ws_path: ws
 # Timeout for requests to the webservice in seconds
 timeout: 10
 # Path of the DAISY Pipeline app or the pipeline launch script to use the webservice.

--- a/dp2/config.yml
+++ b/dp2/config.yml
@@ -1,18 +1,20 @@
-#WS CONFIGURATION
+# Pipeline's webservice host
 host: http://localhost
+# Pipeline's webservice port
 port: 8181
-ws_path: ws
-ws_timeup: 25
-#DP2 launch config 
-exec_line: ../../../../../../../daisy/pipeline-assembly/target/dev-launcher/bin/pipeline2
-
-local: true
-# ROBOT CONF
-client_key: clientid
-client_secret: supersecret
-#connection settings
+# Pipeline's webservice path, as in HOST:PORT/PATH (e.g. http://localhost:8181/ws)
+path: ws
+# Timeout for requests to the webservice in seconds
 timeout: 10
-#debug
-debug: false
-starting: true
+# Path of the DAISY Pipeline app or the pipeline launch script to use the webservice.
+# If empty or only containing 'DAISY Pipeline', the app is searched in the PATH
+#app_path:
+# Client key for authenticated requests
+#client_key:
+# Client secrect for authenticated requests
+#client_secret:
 
+# Print debug messages
+debug: false
+# Start the webservice or the DAISY Pipeline app in the local computer if it is not running
+starting: false

--- a/dp2/config.yml
+++ b/dp2/config.yml
@@ -1,20 +1,30 @@
-# Pipeline's webservice host
-host: http://localhost
-# Pipeline's webservice port
-port: 8181
-# Pipeline's webservice path, as in HOST:PORT/PATH (e.g. http://localhost:8181/ws)
-ws_path: ws
+# Host part of webservice address
+# Leave empty if you wish to use the app_path setting
+#host: http://localhost
+
+# Port part of webservice address
+# Leave empty if you wish to use the app_path setting
+#port: 8181
+
+# Path part of webservice address, as in HOST:PORT/PATH (e.g. http://localhost:8181/ws)
+# Leave empty if you wish to use the app_path setting
+#ws_path: ws
+
 # Timeout for requests to the webservice in seconds
 timeout: 10
-# Path of the DAISY Pipeline app or the pipeline launch script to use the webservice.
-# If empty or only containing 'DAISY Pipeline', the app is searched in the PATH
+
+# Path to the DAISY Pipeline app
+# If left empty, the PATH is searched for a "DAISY Pipeline" executable
 #app_path:
+
 # Client key for authenticated requests
-#client_key:
+#client_key: your-id
+
 # Client secrect for authenticated requests
-#client_secret:
+#client_secret: your-password
 
 # Print debug messages
 debug: false
-# Start the webservice or the DAISY Pipeline app in the local computer if it is not running
+
+# Start the DAISY Pipeline app if it is not running
 starting: false

--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,5 @@ require (
 	golang.org/x/mod v0.7.0
 	golang.org/x/tools v0.5.0
 	launchpad.net/goyaml v0.0.0-20140305200416-000000000051
+	github.com/mitchellh/go-ps v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uia
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/mattn/goveralls v0.0.11 h1:eJXea6R6IFlL1QMKNMzDvvHv/hwGrnvyig4N+0+XiMM=
 github.com/mattn/goveralls v0.0.11/go.mod h1:gU8SyhNswsJKchEV93xRQxX6X3Ei4PJdQk/6ZHvrvRk=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
 github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>cli</artifactId>
-  <version>2.2.2-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>DAISY Pipeline 2 :: Command Line Interface</name>
   <description>Command Line Interface for the DAISY Pipeline 2.</description>


### PR DESCRIPTION
This PR changes the initialisation process of the command line interface, to allow the use of the DAISY Pipeline electron app :

Additionally, the following settings have been removed or renamed as requested :
- `exec_line` has been renamed as `app_path`
  - If this setting is pointing to a DAISY Pipeline app executable (`DAISY Pipeline` or `DAISY Pipeline.exe`), it will try to launch the app with the requested command line arguments
  - Using the string value `DAISY Pipeline` will look for the DAISY Pipeline app in the user path.
- `ws_timeup` has been removed
  - It's usage in code is replaced by the previous default value `25` 
- `local` has been removed
- `timeout` has been removed
  - It's usage in code is replaced by the previous default value `25` 
