### PR TITLE
Fixes for DPApp package distribution

### DIFF
--- a/cli/link.go
+++ b/cli/link.go
@@ -94,6 +94,10 @@ func bringUp(pLink *PipelineLink) error {
 	var alive pipeline.Alive
 	var err error
 	defaultConf := copyConf()
+	// if no configuration is defined, use the default one
+	if pLink.config == nil {
+		pLink.config = defaultConf
+	}
 	host_configured := pLink.config[HOST] != nil && pLink.config[HOST].(string) != ""
 	port_configured := pLink.config[PORT] != nil && pLink.config[PORT].(int) != 0
 	path_configured := pLink.config[PATH] != nil && pLink.config[PATH].(string) != ""

--- a/cli/link.go
+++ b/cli/link.go
@@ -94,12 +94,24 @@ func bringUp(pLink *PipelineLink) error {
 	var alive pipeline.Alive
 	var err error
 	defaultConf := copyConf()
-	if !((pLink.config[HOST] == nil || pLink.config[HOST].(string) == "") &&
-		 (pLink.config[HOST] == nil || pLink.config[PORT].(int) == 0) &&
-		 (pLink.config[PATH] == nil || pLink.config[PATH].(string) == "")) {
-		// A webservice is configured to be used in loaded configuration either from
+	host_configured := pLink.config[HOST] != nil && pLink.config[HOST].(string) != ""
+	port_configured := pLink.config[PORT] != nil && pLink.config[PORT].(int) != 0
+	path_configured := pLink.config[PATH] != nil && pLink.config[PATH].(string) != ""
+	if host_configured || port_configured || path_configured {
+		// A webservice is at least partially configured to be used in loaded configuration either from
 		// - the user provided config (config file or command line)
 		// - The default webservice config, reinstated due to missing or incorrect app path
+		if !host_configured {
+			pLink.config[HOST] = defaultConf[HOST]
+		}
+		if !port_configured {
+			pLink.config[PORT] = defaultConf[PORT]
+		}
+		if !path_configured {
+			pLink.config[PATH] = defaultConf[PATH]
+		}
+		log.Printf("Trying to connect to the webservice at %s\n", pLink.config.Url())
+		pLink.pipeline.SetUrl(pLink.config.Url())
 		alive, err = pLink.pipeline.Alive()
 		if err != nil {
 			if pLink.config[STARTING] != nil && pLink.config[STARTING].(bool) {

--- a/cli/link.go
+++ b/cli/link.go
@@ -93,6 +93,7 @@ func (p PipelineLink) IsLocal() bool {
 func bringUp(pLink *PipelineLink) error {
 	var alive pipeline.Alive
 	var err error
+	defaultConf := copyConf()
 	if !((pLink.config[HOST] == nil || pLink.config[HOST].(string) == "") &&
 		 (pLink.config[HOST] == nil || pLink.config[PORT].(int) == 0) &&
 		 (pLink.config[PATH] == nil || pLink.config[PATH].(string) == "")) {
@@ -123,6 +124,7 @@ func bringUp(pLink *PipelineLink) error {
 			}
 		}
 	} else {
+		log.Println("No webservice configured, trying to start the app if possible")
 		// No webservice configured from initial configuration checks
 		// Check if Pipeline app is running
 		processes, err := ps.Processes()
@@ -186,8 +188,10 @@ func bringUp(pLink *PipelineLink) error {
 					"could not locate the Pipeline app")
 			}
 		}
-		// fallback to default configuration
-		pLink.config = copyConf()
+		log.Println("No webservice specified and app start not set to true, trying to connect to the default webservice address")
+		pLink.config[HOST] = defaultConf[HOST]
+		pLink.config[PORT] = defaultConf[PORT]
+		pLink.config[PATH] = defaultConf[PATH]
 		pLink.pipeline.SetUrl(pLink.config.Url())
 		alive, err = pLink.pipeline.Alive()
 		if err != nil {


### PR DESCRIPTION
This PR includes the following changes :
- Avoid completely resetting configuration (including command line arguments) when no webservice is configured and the app is not found.
  - this should fix the issue reported in https://github.com/daisy/pipeline-ui/issues/395
- When a webservice is partially configured in config or command line, the `host:port/path` definition of the pipeline url is completed with default values
  - for example, this would avoid issues when testing local instances running on different ports, so that providing only  `--port XXXX` would set pipeline url to `http://localhost:XXXX/ws`
